### PR TITLE
add contents: write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This pull request includes a small update to the GitHub Actions workflow for the release process. The change adds permissions for writing to the `contents` scope in the `release` job.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R14-R15): Added `permissions` with `contents: write` to the `release` job.