### PR TITLE
add pull-requests: write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by modifying the permissions granted to the job.

Workflow permissions update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R16): Added `pull-requests: write` permission to the `jobs` section to enable the workflow to create or update pull requests.