### PR TITLE
add pull request event

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,7 @@ on:
       - opened
 jobs:
   run_if:
-    if: startsWith(github.head_ref, 'changeset-release/main/')
+    if: startsWith(github.head_ref, 'changeset-release/')
     runs-on: ubuntu-latest
     steps:
       - name: Get PR Details

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,30 +1,46 @@
+name: Changeset Release PR Notification
+
 on:
   pull_request:
     types:
       - opened
+    branches:
+      - main
+
 jobs:
-  run_if:
-    if: startsWith(github.head_ref, 'changeset-release/')
+  notify-slack:
+    if: startsWith(github.event.pull_request.head.ref, 'changeset-release/')
     runs-on: ubuntu-latest
     steps:
       - name: Get PR Details
         id: pr-details
         run: |
-          echo "pr_number=$(echo ${{ github.event.pull_request.number }} | cut -c1-7)" >> $GITHUB_OUTPUT
+          echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "pr_title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+          echo "pr_url=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {
-              "text": "Beep-beep! New jeepney-design-system changeset: ${{ steps.pr-details.outputs.pr_number }}",
+              "text": "🚀 New changeset release PR opened for jeepney-design-system!",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*PR # ${{ steps.pr-details.outputs.pr_number }}:* <https://github.com/adobocorp/jeepney-design-system/pull/${{ steps.pr-details.outputs.pr_number }}|Click here to visit Example.com>"
+                    "text": "*PR #${{ steps.pr-details.outputs.pr_number }}:* ${{ steps.pr-details.outputs.pr_title }}\n\n:point_right: <${{ steps.pr-details.outputs.pr_url }}|View Pull Request>"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Repository: `${{ github.repository }}` | Branch: `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`"
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
- **remove slack from release and move it to its own action**
- **modify filtering rule**
This pull request introduces a new GitHub Actions workflow for notifying Slack about changeset release pull requests and removes Slack notification functionality from the existing release workflow. The changes streamline notification processes and separate concerns between workflows.

### Added functionality:

* **New Slack notification workflow for changeset release PRs**: Added a `.github/workflows/pull-request.yml` file to notify Slack when a pull request with a `changeset-release/` prefix is opened on the `main` branch. The notification includes PR details such as number, title, and URL.

### Removed functionality:

* **Slack notifications for releases**: Removed Slack notification steps from the `.github/workflows/release.yml` file, including commit info extraction and notification payloads for main branch pushes. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-L28) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L60-L127)
- **add more details to slack**
