### PR TITLE
update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,10 +174,10 @@ importers:
         specifier: 'catalog:'
         version: 1.0.0-beta.1(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@jeepney-design-system/tokens':
-        specifier: workspace:^0.0.3
+        specifier: workspace:^0.0.4
         version: link:../../packages/tokens
       '@jeepney-design-system/ui':
-        specifier: workspace:^0.0.3
+        specifier: workspace:^0.0.4
         version: link:../../packages/ui
       '@tanstack/react-query':
         specifier: 'catalog:'
@@ -196,7 +196,7 @@ importers:
         version: 3.1.0(@storybook/blocks@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.6.2)))(@storybook/channels@8.6.14(storybook@8.6.14(prettier@3.6.2)))(@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2)))(@storybook/core-events@8.6.14(storybook@8.6.14(prettier@3.6.2)))(@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.6.2)))(@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.6.2)))(@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.1.0(react@19.1.0))(react-router-dom@7.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@jeepney-design-system/tsconfig':
-        specifier: workspace:^0.0.3
+        specifier: workspace:^0.0.4
         version: link:../../packages/tsconfig
       '@storybook/addon-actions':
         specifier: 'catalog:'


### PR DESCRIPTION
This pull request updates the workspace dependencies in the `pnpm-lock.yaml` file to use version `0.0.4` instead of `0.0.3`. These changes ensure that the project is aligned with the latest versions of the internal packages.

Dependency updates:

* Updated the `specifier` for `@jeepney-design-system/tokens` to `workspace:^0.0.4`.
* Updated the `specifier` for `@jeepney-design-system/ui` to `workspace:^0.0.4`.
* Updated the `specifier` for `@jeepney-design-system/tsconfig` to `workspace:^0.0.4`.